### PR TITLE
All day view, maintaining +4 offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
       --fc-button-hover-bg-color: rgb(24, 44, 87);
       --fc-button-hover-border-color: rgb(24, 44, 87);
     }
+    body {
+      margin: 8px;
+      height: calc(100svh - 8px * 2);
+      display: flex;
+      flex-flow: column;
+    }
+    h2 {
+      margin-top: 0;
+    }
     .btn {
       font-size: 18px;
       background-color: var(--fc-button-bg-color);
@@ -62,6 +71,14 @@
       border-bottom-left-radius: 0;
     }
 
+    #calendar {
+      flex: 1;
+      overflow-y: hidden;
+    }
+    .fc-view-harness {
+      flex: 1;
+      overflow-y: scroll;
+    }
     .fc-button-group {
       gap: 2px;
     }

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       var offsetDifference = targetTimezoneOffset - localTimezoneOffset;
 
       // Target times in +2 timezone
-      var targetSlotMinTime = '16:00:00';
+      var targetSlotMinTime = '04:00:00';
       var targetSlotMaxTime = '28:00:00';
 
       // Convert target times to local times based on the offset difference
@@ -180,6 +180,7 @@
       calendar.destroy();
       calendar.render();
       localStorage.setItem('timezone', targetTimezone);
+      scrollToNowIndicator()
     }
 
     // Get the event time format based on the selected time format
@@ -211,6 +212,7 @@
       calendar.setOption('eventTimeFormat', eventTimeFormat);
       calendar.setOption('slotLabelFormat', slotLabelFormat);
       localStorage.setItem('timeFormat', timeFormat);
+      scrollToNowIndicator()
     }
 
     function getWeekStart(weekStart) {
@@ -272,12 +274,20 @@
       calendar.render();
     }
 
+    function scrollToNowIndicator() {
+      document.querySelector(".fc-timegrid-now-indicator-line").scrollIntoView({
+        behavior: "smooth",
+        block: "center",
+      })
+    }
+
     // On page load, initialize the calendar with the saved timezone and time format
     document.addEventListener('DOMContentLoaded', function() {
       const timezone = localStorage.getItem('timezone') ?? 'local';
       const timeFormat = localStorage.getItem('timeFormat') ?? '24h';
       const weekStart = localStorage.getItem('weekStart') ?? 'monday';
       initCalendar(timezone, timeFormat, weekStart);
+      scrollToNowIndicator()
     });
   </script>
 </body>


### PR DESCRIPTION
Grubby said he should be able to see all day if he wanted to in yesterday stream. He scheduled today's AoC starting from 14:00 but was cut off because calendar start from 16:00. He usually doesn't stream at 14:00.
I set the start time to 04:00, maintaining the previous end time offset and automatically scroll to now indicator on load, when timezone changed or when time format changed. Although while writing this, i think it'd be a better idea if only the calendar scrolled and not the whole web page so that controls can stick on top